### PR TITLE
未ログイン時、ログイン画面へ遷移させる

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,6 +1,7 @@
 class MessagesController < ApplicationController
   before_action :set_group
   before_action :move_to_index, except: :index
+  before_action :authenticate_user!
 
   def index
     @message = Message.new


### PR DESCRIPTION
#What
未ログインユーザーがグループにアクセスした時、ログイン画面へ遷移させるようにした。

#Why
未ログインユーザーにメッセージを送らせないため。